### PR TITLE
css.js bug resulting in broken background-image

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -7,7 +7,7 @@ var CSSParser = {
             (function () {
                 var item = temp[i];
                 if (item) {
-                    var prop = item.split(':');
+                    var prop = item.split(/\:(.+)/);
 
                     if (!prop[1]) {
                         throw 'CSS format is invalid: "' + item + '"';


### PR DESCRIPTION
`var prop = item.split(':');`
replaced with split on first occurence:
`var prop = item.split(/\:(.+)/);`

data:
`{
  page: {
	banner_image: 'path/to/file.jpg'
  }
}`

element:
`<div :style="{ backgroundImage: 'url(' + page.banner_image + ')' }"  style="background-image: url(http://placehold.it/300x200)"></div>`

faulty result:
`<div style="background-image: url(http; background-image: url(path/to/file.jpg);">`

after fix:
`<div style="background-image: url(http://placehold.it/300x200); background-image: url(path/to/file.jpg);"></div>`