### PR TITLE
Add vuex compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+node_js:
+  - "4"
 notifications:
   webhooks:
     urls:

--- a/src/renderer/scope.js
+++ b/src/renderer/scope.js
@@ -560,20 +560,24 @@ module.exports = function (globals) {
         // Compute "computed" props
         buildComputedProps: function (vm) {
             if (vm.$options.computed) {
-                var item;
                 for (var name in vm.$options.computed) {
-                    item = vm.$options.computed[name];
-
+                    const item = vm.$options.computed[name];
                     if (typeof item === 'function') {
-                        try {
-                            vm[name] = item.call(vm);
-                        } catch (error) {
-                            vm.__states.$logger.debug(
-                                'Computed property "' + name + '" compilation error',
-                                common.onLogMessage(vm), '\n',
-                                error
-                            );
-                        }
+                        Object.defineProperty(vm, name, {
+                            get: function () {
+                                try {
+                                    return item.call(vm)
+                                } catch (error) {
+                                    vm.__states.$logger.debug(
+                                        'Computed property "' + name + '" compilation error',
+                                        common.onLogMessage(vm), '\n',
+                                        error
+                                    );
+                                }
+                            },
+                            configurable: true,
+                            enumerable: true
+                        })
                     } else {
                         try {
                             vm[name] = item.get.call(vm);


### PR DESCRIPTION
Add .use method to the Vue prototype.

Rework computed properties in order to use Vuex mapState and mapGetters helpers.